### PR TITLE
Stop emitting .com domains as spurious filename IOCs

### DIFF
--- a/iocparser/infrastructure/extractor_base.py
+++ b/iocparser/infrastructure/extractor_base.py
@@ -206,6 +206,32 @@ def _separate_fingerprints_from_md5(iocs: dict[str, list[str]]) -> None:
         del iocs["md5"]
 
 
+def _drop_domain_filenames(iocs: dict[str, list[str]]) -> None:
+    """Drop filename candidates that are really domains/hosts.
+
+    The filename extension list includes ``com`` (legacy DOS executables), which
+    also matches the ``.com`` TLD, so every ``foo.com`` domain was double-emitted
+    as a spurious filename. A token already recognised as a domain/host is not a
+    file; keep it only under its network type. Domains are defanged (``[.]``) while
+    filenames stay raw, so refang for the comparison.
+    """
+    filenames = iocs.get("filenames")
+    if not filenames:
+        return
+    domain_values = {
+        value.replace("[.]", ".").lower()
+        for type_name in ("domains", "hosts")
+        for value in iocs.get(type_name) or ()
+    }
+    if not domain_values:
+        return
+    remaining = [name for name in filenames if name.lower() not in domain_values]
+    if remaining:
+        iocs["filenames"] = remaining
+    else:
+        del iocs["filenames"]
+
+
 class ExtractorBase:
     """Shared helper methods for IOC extraction."""
 
@@ -417,6 +443,7 @@ class ExtractionAggregateMixin:
                 iocs[ioc_type] = results
 
         _separate_fingerprints_from_md5(iocs)
+        _drop_domain_filenames(iocs)
         return iocs
 
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -308,6 +308,22 @@ class TestNetworkExtractors:
         result = self.extractor.extract_mac_addresses("Cisco MAC: AABB.CCDD.EEFF")
         assert result == ["aa:bb:cc:dd:ee:ff"]
 
+    def test_com_domain_not_emitted_as_filename(self):
+        """A ``.com`` domain must not be double-reported as a filename.
+
+        Regression: ``com`` is in the filename extension list (legacy DOS
+        executables), but it also matches the ``.com`` TLD, so every ``foo.com``
+        domain was spuriously duplicated into ``filenames``.
+        """
+        result = self.extractor.extract_all("visit evil-domain.com and host sub.bad.com")
+        assert "evil-domain.com" in result.get("domains", [])
+        assert "evil-domain.com" not in result.get("filenames", [])
+        assert "sub.bad.com" not in result.get("filenames", [])
+        # Genuine files (including a ``.com`` infix) are still extracted.
+        files = self.extractor.extract_all("drop payload.com.exe and report.docx")
+        assert "payload.com.exe" in files.get("filenames", [])
+        assert "report.docx" in files.get("filenames", [])
+
 
 class TestEmailAndCommunication:
     """Test email and communication IOC extraction."""


### PR DESCRIPTION
## Problem
The filename extension list in `extractor_patterns.py` includes `com` (for legacy DOS executables), which also matches the `.com` TLD. As a result **every `foo.com` domain was double-emitted**: once as a domain/host and again as a bogus `filename` IOC. This polluted filename output in essentially every threat report and showed up across STIX export and run-diff output.

## Fix
Reconcile after extraction (mirroring the existing `_separate_fingerprints_from_md5`): `_drop_domain_filenames()` in `extractor_base.py`, called from `extract_all()`, drops filename candidates already recognised as a domain/host. It refangs `[.]`→`.` for the comparison since domains are defanged while filenames stay raw.

`.com` is the only filename extension that collides with a common TLD, so `.exe`/`.zip`/`.docx`/`payload.com.exe` filenames are untouched. The fix also covers the streaming path (which extracts per chunk via `extract_all`).

## Test
`test_com_domain_not_emitted_as_filename` — asserts a `.com` domain is not emitted as a filename while genuine files (incl. a `.com` infix) still are.

Full suite (1684) + ruff + mypy + arch-guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)