### PR TITLE
Reject negative --retain-days instead of silently wiping all history

### DIFF
--- a/iocparser/cli_schema.py
+++ b/iocparser/cli_schema.py
@@ -10,7 +10,10 @@ from sqlalchemy.engine import Engine
 
 from iocparser import cli_args as _cli_args
 from iocparser import cli_output as _cli_output
-from iocparser.api_persistence_query import validated_non_negative_int
+from iocparser.api_persistence_query import (
+    validated_non_negative_days,
+    validated_non_negative_int,
+)
 from iocparser.application.contracts import ListFailedBatchesInput, RetainHistoryInput
 from iocparser.application.maintenance_use_cases import (
     compact_persisted_history as uc_compact_persisted_history,
@@ -143,7 +146,10 @@ def _handle_history_maintenance(args: argparse.Namespace, config: AppConfig) -> 
     if retain_days is not None:
         deleted = uc_retain_persisted_history(
             RetainHistoryInput(
-                days=_cli_args.int_arg_value(retain_days, "retain-days"),
+                # Reject a negative --retain-days at the CLI boundary like the public API
+                # does; retain_history clamps it to 0 (cutoff == now), which would silently
+                # delete the ENTIRE history instead of erroring on invalid input.
+                days=validated_non_negative_days(retain_days),
                 statuses=_cli_args.parse_string_filters(
                     _cli_args.namespace_value(args, "prune_status")
                 ),

--- a/tests/test_operational_maturity.py
+++ b/tests/test_operational_maturity.py
@@ -1675,6 +1675,37 @@ def test_cli_schema_commands_and_history_io(tmp_path: Path, capsys) -> None:
     assert "baseline" in capsys.readouterr().out
 
 
+def test_cli_negative_retain_days_rejected_and_does_not_wipe_history(tmp_path: Path) -> None:
+    """Regression: a negative --retain-days must be rejected, not silently delete everything.
+
+    retain_history clamps days to 0 (cutoff == now), so an unvalidated negative value
+    pruned the entire history. The public API rejected it but the CLI handler did not.
+    """
+    db_uri = f"sqlite:///{tmp_path / 'retain.sqlite'}"
+    _persist_result(db_uri, source_value="keep.txt", ioc_value="keep.example")
+    config = load_config(True, db_uri, None)
+    writer = _Writer()
+
+    args = SimpleNamespace(
+        schema_version=False,
+        migrate=False,
+        validate_schema=False,
+        export_history=None,
+        archive_history=None,
+        import_history=None,
+        restore_history=None,
+        compact_history=False,
+        retain_days=-5,
+        prune_status=None,
+        list_failed_batches=False,
+        batch_limit=20,
+    )
+    with pytest.raises(ValidationError, match="Invalid days"):
+        handle_schema_commands(args, config, file_writer=writer)
+    # The history must be untouched after the rejected request.
+    assert query_persisted_runs(db_uri=db_uri, limit=10).total >= 1
+
+
 def test_cli_schema_validation_errors_and_noop() -> None:
     writer = _Writer()
     config = load_config(True, None, None)


### PR DESCRIPTION
## Problem (data loss)
The CLI history-maintenance handler built `RetainHistoryInput` with `int_arg_value(retain_days, ...)`, which only parses the int — it does **not** reject negatives. `retain_history` then computes `cutoff = now - timedelta(days=max(0, days))`, so any negative value clamps to `now` and prunes **every** run started before now, deleting the entire persisted history.

The public API (`retain_persisted_history`) already guards this via `validated_non_negative_days`; the CLI path did not, so the two trust boundaries disagreed and `--retain-days -5` silently wiped everything (verified 2 runs → 0).

## Fix
Route the CLI handler through the same `validated_non_negative_days` validator, so a negative value raises `Invalid days` and leaves the store untouched.

## Test
`test_cli_negative_retain_days_rejected_and_does_not_wipe_history` — persists a run, asserts `--retain-days -5` raises `ValidationError`, and asserts the run survives.

Full suite (1684) + ruff + mypy + arch-guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)