### PR TITLE
Make hostname-warninglist regression test hermetic (fix flaky CI)

### DIFF
--- a/tests/test_regression_loop_fixes.py
+++ b/tests/test_regression_loop_fixes.py
@@ -1094,12 +1094,31 @@ def test_hostname_type_warning_lists_match() -> None:
 
     Only string/regex/cidr list types were indexed, so the 19 shipped
     hostname-type lists were inert and never flagged a value.
-    """
-    from iocparser.infrastructure.warninglists_service import MISPWarningListService
 
-    warning_lists = MISPWarningListService()._get_lists(force_update=False)
+    Built from a hermetic in-memory fixture (not a live MISP download) so the
+    regression can never flake on a GitHub API rate limit in CI: the original
+    body called ``_get_lists(force_update=False)``, which fell back to a network
+    fetch when no cache existed and returned an empty set on HTTP 403, failing
+    the assertion for an environmental reason rather than a real regression.
+    """
+    from iocparser.infrastructure.warninglists import MISPWarningLists
+
+    warning_lists = MISPWarningLists()
+    warning_lists.warning_lists = {
+        "hostname-list": {
+            "name": "Top hostnames",
+            "type": "hostname",
+            "matching_attributes": ["domain", "hostname"],
+            "list": ["google.com"],
+        }
+    }
+    warning_lists._preprocess_lists()
     matched, _info = warning_lists.check_value("google.com", "domains")
     assert matched is True
+    # A value absent from the hostname list must not match, proving the True
+    # above comes from hostname-type indexing rather than a blanket pass.
+    unmatched, _ = warning_lists.check_value("not-listed-example.test", "domains")
+    assert unmatched is False
 
 
 def test_url_batch_file_honors_bom_and_utf16(tmp_path: Path) -> None:

--- a/tests/test_warninglists_offline.py
+++ b/tests/test_warninglists_offline.py
@@ -473,3 +473,85 @@ def test_warninglist_lookup_helpers_cover_url_substring_and_invalid_inputs(tmp_p
 
     assert warning_lists._extract_domain_from_url("http://[::1") is None
     assert warning_lists._check_cidr("203.0.113.10", [None, "203.0.113.0/24"]) is True
+
+
+def test_matching_attribute_name_rejects_dict_with_non_string_name() -> None:
+    """A {'name': <non-str>} matching-attribute entry must raise, not coerce.
+
+    Hermetic coverage for warninglists_types.matching_attribute_name's dict
+    branch, previously exercised only by live MISP data whose download flakes
+    in CI on a GitHub rate limit.
+    """
+    from iocparser.errors import TypeValidationError
+    from iocparser.infrastructure.warninglists_types import matching_attribute_name
+
+    assert matching_attribute_name("domain") == "domain"
+    assert matching_attribute_name({"name": "hostname"}) == "hostname"
+    with pytest.raises(TypeValidationError):
+        matching_attribute_name({"name": 123})
+
+
+def test_email_domain_in_warning_list_checks_extracted_domain(tmp_path: Path) -> None:
+    """_email_domain_in_warning_list must look up the extracted domain.
+
+    Hermetic coverage for warninglists_matching line that delegates to
+    check_value(domain, 'domains') once an email yields a non-empty domain.
+    """
+    warning_lists = OfflineWarningLists(tmp_path)
+    warning_lists.warning_lists = {
+        "bad-domains": {
+            "name": "Bad Domains",
+            "type": "string",
+            "matching_attributes": ["domain", "hostname"],
+            "list": ["phish.example"],
+        }
+    }
+    warning_lists._preprocess_lists()
+    matched, _info = warning_lists._email_domain_in_warning_list("victim@phish.example")
+    assert matched is True
+    unmatched, info = warning_lists._email_domain_in_warning_list("victim@clean.example")
+    assert unmatched is False
+    assert info is None
+
+
+def test_regex_warning_list_parses_slash_delimited_flags(tmp_path: Path) -> None:
+    """`/body/flags` regex entries must parse m/s/x flags and reject bad flags.
+
+    Hermetic coverage for warninglists_preprocess regex-flag parsing (the m/s/x
+    branches and the invalid-flags early return), previously only reached by
+    live MISP regex lists.
+    """
+    warning_lists = OfflineWarningLists(tmp_path)
+    warning_lists.warning_lists = {
+        "regex-flags": {
+            "name": "Regex Flags",
+            "type": "regex",
+            "matching_attributes": ["domain"],
+            # /body/msx exercises the MULTILINE + DOTALL + VERBOSE branches and
+            # the success return; /bad/9 has non-alpha flags and hits the early
+            # return; /skip/g exercises the ignored-"g"-flag continue branch.
+            "list": [r"/evil\.example/msx", r"/other\.example/9", r"/skip\.example/g"],
+        }
+    }
+    warning_lists._preprocess_lists()
+    matched, _info = warning_lists.check_value("evil.example", "domains")
+    assert matched is True
+
+
+def test_check_regex_type_treats_timeout_as_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A regex match that times out must be swallowed as 'no match', not raised.
+
+    Hermetic coverage for warninglists_match_checks' TimeoutError branch: the
+    `regex` engine's per-match timeout firing on a catastrophic warning-list
+    pattern must not abort the run.
+    """
+    import logging
+
+    from iocparser.infrastructure import warninglists_match_checks as match_checks
+
+    def _raise_timeout(*_args: object, **_kwargs: object) -> bool:
+        raise TimeoutError
+
+    monkeypatch.setattr(match_checks.regex, "search", _raise_timeout)
+    result = match_checks.check_regex_type(lambda: logging.getLogger("test"), "value", [r"(a+)+$"])
+    assert result is False


### PR DESCRIPTION
## Problem
`test_hostname_type_warning_lists_match` calls `MISPWarningListService()._get_lists(force_update=False)`, which falls back to a **live download** from the GitHub MISP warninglists repo when no cache is present. In CI the request hits `403 rate limit exceeded`, the service returns an empty set, and the assertion fails — turning every matrix job red for an environmental reason unrelated to the code under test. (This is why PRs #9/#10 show red CI despite passing locally.)

## Fix
Rebuild the same invariant from an in-memory `hostname`-type list fixture + `_preprocess_lists()` — the exact pattern the sibling `test_get_warnings_for_iocs_matches_email_domain` already uses — so the test exercises hostname-type indexing deterministically with zero network. Added a negative control so the positive assertion can only come from hostname-type indexing, not a blanket pass.

Verified hermetic by running the body with `requests.get` rigged to raise (passes, no network call).

No production code changed; this only de-flakes the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)